### PR TITLE
Seperate git-scm and github.

### DIFF
--- a/bingo-hosts/git-scm.hosts
+++ b/bingo-hosts/git-scm.hosts
@@ -1,0 +1,4 @@
+54.243.57.144    git-scm.com
+75.101.145.87    git-scm.com
+75.101.163.44    git-scm.com
+174.129.212.2    git-scm.com

--- a/bingo-hosts/github.hosts
+++ b/bingo-hosts/github.hosts
@@ -79,8 +79,3 @@
 185.31.17.185    github.global.ssl.fastly.net
 185.31.17.184    github.global.ssl.fastly.net
 185.31.16.184    github.global.ssl.fastly.net
-
-54.243.57.144    git-scm.com
-75.101.145.87    git-scm.com
-75.101.163.44    git-scm.com
-174.129.212.2    git-scm.com


### PR DESCRIPTION
Although git-scm is hosted at github, I still think it is better
to seperate them. There are a lot of sites hosted on github
actually. And we may need to add them in future.
